### PR TITLE
Tests: Use luassert match.is_ref to check for same instance in tests

### DIFF
--- a/spec/unit/always_fail_decorator_spec.lua
+++ b/spec/unit/always_fail_decorator_spec.lua
@@ -1,4 +1,5 @@
 require 'spec/custom_asserts'
+local match = require("luassert.match")
 local BehaviourTree = require 'lib/behaviour_tree'
 local AlwaysFailDecorator = BehaviourTree.AlwaysFailDecorator
 
@@ -48,7 +49,7 @@ describe('AlwaysFailDecorator', function()
     it('should call start on the node', function()
       stub(task, 'start')
       subject:start('foobar')
-      assert.stub(task.start).was.called_with(task, 'foobar')
+      assert.stub(task.start).was.called_with(match.is_ref(task), 'foobar')
     end)
   end)
 
@@ -61,7 +62,7 @@ describe('AlwaysFailDecorator', function()
     it('should call finish on the node', function()
       stub(task, 'finish')
       subject:finish('foobar')
-      assert.stub(task.finish).was.called_with(task, 'foobar')
+      assert.stub(task.finish).was.called_with(match.is_ref(task), 'foobar')
     end)
   end)
 
@@ -79,7 +80,7 @@ describe('AlwaysFailDecorator', function()
     it('should call run on the node', function()
       stub(task, 'run')
       subject:run('foobar')
-      assert.stub(task.run).was.called_with(task, 'foobar')
+      assert.stub(task.run).was.called_with(match.is_ref(task), 'foobar')
     end)
   end)
 

--- a/spec/unit/always_succeed_decorator_spec.lua
+++ b/spec/unit/always_succeed_decorator_spec.lua
@@ -1,4 +1,5 @@
 require 'spec/custom_asserts'
+local match = require("luassert.match")
 local BehaviourTree = require 'lib/behaviour_tree'
 local AlwaysSucceedDecorator = BehaviourTree.AlwaysSucceedDecorator
 
@@ -48,7 +49,7 @@ describe('AlwaysSucceedDecorator', function()
     it('should call start on the node', function()
       stub(task, 'start')
       subject:start('foobar')
-      assert.stub(task.start).was.called_with(task, 'foobar')
+      assert.stub(task.start).was.called_with(match.is_ref(task), 'foobar')
     end)
   end)
 
@@ -61,7 +62,7 @@ describe('AlwaysSucceedDecorator', function()
     it('should call finish on the node', function()
       stub(task, 'finish')
       subject:finish('foobar')
-      assert.stub(task.finish).was.called_with(task, 'foobar')
+      assert.stub(task.finish).was.called_with(match.is_ref(task), 'foobar')
     end)
   end)
 
@@ -74,12 +75,12 @@ describe('AlwaysSucceedDecorator', function()
     it('should set control on the node', function()
       stub(task, 'setControl')
       subject:run('foobar')
-      assert.stub(task.setControl).was.called_with(task, subject)
+      assert.stub(task.setControl).was.called_with(match.is_ref(task), subject)
     end)
     it('should call run on the node', function()
       stub(task, 'run')
       subject:run('foobar')
-      assert.stub(task.run).was.called_with(task, 'foobar')
+      assert.stub(task.run).was.called_with(match.is_ref(task), 'foobar')
     end)
   end)
 

--- a/spec/unit/branch_node_spec.lua
+++ b/spec/unit/branch_node_spec.lua
@@ -1,4 +1,5 @@
 require 'spec/custom_asserts'
+local match = require("luassert.match")
 local BehaviourTree = require 'lib/behaviour_tree'
 
 describe('BranchNode', function()
@@ -75,12 +76,12 @@ describe('BranchNode', function()
     it('should set the current nodes control', function()
       stub(node, 'setControl')
       subject:_run()
-      assert.stub(node.setControl).was.called_with(node, subject)
+      assert.stub(node.setControl).was.called_with(match.is_ref(node), subject)
     end)
     it('should call start on the current node if first run', function()
       stub(node, 'start')
       subject:_run('foo')
-      assert.stub(node.start).was.called_with(node, 'foo')
+      assert.stub(node.start).was.called_with(match.is_ref(node), 'foo')
     end)
     it('should not call start on the current node if running', function()
       subject.node = node
@@ -92,7 +93,7 @@ describe('BranchNode', function()
     it('should call run on the current node', function()
       stub(node, 'run')
       subject:_run('foo')
-      assert.stub(node.run).was.called_with(node, 'foo')
+      assert.stub(node.run).was.called_with(match.is_ref(node), 'foo')
     end)
   end)
 

--- a/spec/unit/decorator_spec.lua
+++ b/spec/unit/decorator_spec.lua
@@ -1,4 +1,5 @@
 require 'spec/custom_asserts'
+local match = require("luassert.match")
 local BehaviourTree = require 'lib/behaviour_tree'
 local Decorator = BehaviourTree.Decorator
 
@@ -48,7 +49,7 @@ describe('Decorator', function()
     it('should call start on the node', function()
       stub(task, 'start')
       subject:start('foobar')
-      assert.stub(task.start).was.called_with(task, 'foobar')
+      assert.stub(task.start).was.called_with(match.is_ref(task), 'foobar')
     end)
   end)
 
@@ -61,7 +62,7 @@ describe('Decorator', function()
     it('should call finish on the node', function()
       stub(task, 'finish')
       subject:finish('foobar')
-      assert.stub(task.finish).was.called_with(task, 'foobar')
+      assert.stub(task.finish).was.called_with(match.is_ref(task), 'foobar')
     end)
   end)
 
@@ -74,12 +75,12 @@ describe('Decorator', function()
     it('should set control on the node', function()
       stub(task, 'setControl')
       subject:run('foobar')
-      assert.stub(task.setControl).was.called_with(task, subject)
+      assert.stub(task.setControl).was.called_with(match.is_ref(task), subject)
     end)
     it('should call run on the node', function()
       stub(task, 'run')
       subject:run('foobar')
-      assert.stub(task.run).was.called_with(task, 'foobar')
+      assert.stub(task.run).was.called_with(match.is_ref(task), 'foobar')
     end)
   end)
 

--- a/spec/unit/invert_decorator_spec.lua
+++ b/spec/unit/invert_decorator_spec.lua
@@ -1,3 +1,4 @@
+local match = require("luassert.match")
 local BehaviourTree = require 'lib/behaviour_tree'
 local InvertDecorator = BehaviourTree.InvertDecorator
 
@@ -47,7 +48,7 @@ describe('InvertDecorator', function()
     it('should call start on the node', function()
       stub(task, 'start')
       subject:start('foobar')
-      assert.stub(task.start).was.called_with(task, 'foobar')
+      assert.stub(task.start).was.called_with(match.is_ref(task), 'foobar')
     end)
   end)
 
@@ -60,7 +61,7 @@ describe('InvertDecorator', function()
     it('should call finish on the node', function()
       stub(task, 'finish')
       subject:finish('foobar')
-      assert.stub(task.finish).was.called_with(task, 'foobar')
+      assert.stub(task.finish).was.called_with(match.is_ref(task), 'foobar')
     end)
   end)
 
@@ -73,12 +74,12 @@ describe('InvertDecorator', function()
     it('should set control on the node', function()
       stub(task, 'setControl')
       subject:run('foobar')
-      assert.stub(task.setControl).was.called_with(task, subject)
+      assert.stub(task.setControl).was.called_with(match.is_ref(task), subject)
     end)
     it('should call run on the node', function()
       stub(task, 'run')
       subject:run('foobar')
-      assert.stub(task.run).was.called_with(task, 'foobar')
+      assert.stub(task.run).was.called_with(match.is_ref(task), 'foobar')
     end)
   end)
 

--- a/spec/unit/priority_spec.lua
+++ b/spec/unit/priority_spec.lua
@@ -1,4 +1,5 @@
 require 'spec/custom_asserts'
+local match = require("luassert.match")
 local BehaviourTree = require 'lib/behaviour_tree'
 
 describe('Priority selector', function()
@@ -75,12 +76,12 @@ describe('Priority selector', function()
     it('should set the current nodes control', function()
       stub(node, 'setControl')
       subject:_run()
-      assert.stub(node.setControl).was.called_with(node, subject)
+      assert.stub(node.setControl).was.called_with(match.is_ref(node), subject)
     end)
     it('should call start on the current node if first run', function()
       stub(node, 'start')
       subject:_run('foo')
-      assert.stub(node.start).was.called_with(node, 'foo')
+      assert.stub(node.start).was.called_with(match.is_ref(node), 'foo')
     end)
     it('should not call start on the current node if running', function()
       subject.node = node
@@ -92,7 +93,7 @@ describe('Priority selector', function()
     it('should call run on the current node', function()
       stub(node, 'run')
       subject:_run('foo')
-      assert.stub(node.run).was.called_with(node, 'foo')
+      assert.stub(node.run).was.called_with(match.is_ref(node), 'foo')
     end)
   end)
 

--- a/spec/unit/random_spec.lua
+++ b/spec/unit/random_spec.lua
@@ -1,4 +1,5 @@
 require 'spec/custom_asserts'
+local match = require("luassert.match")
 local BehaviourTree = require 'lib/behaviour_tree'
 
 describe('Random', function()
@@ -84,12 +85,12 @@ describe('Random', function()
     it('should set the current nodes control', function()
       stub(node, 'setControl')
       subject:_run()
-      assert.stub(node.setControl).was.called_with(node, subject)
+      assert.stub(node.setControl).was.called_with(match.is_ref(node), subject)
     end)
     it('should call start on the current node if first run', function()
       stub(node, 'start')
       subject:_run('foo')
-      assert.stub(node.start).was.called_with(node, 'foo')
+      assert.stub(node.start).was.called_with(match.is_ref(node), 'foo')
     end)
     it('should not call start on the current node if running', function()
       subject.node = node
@@ -101,7 +102,7 @@ describe('Random', function()
     it('should call run on the current node', function()
       stub(node, 'run')
       subject:_run('foo')
-      assert.stub(node.run).was.called_with(node, 'foo')
+      assert.stub(node.run).was.called_with(match.is_ref(node), 'foo')
     end)
   end)
 

--- a/spec/unit/sequence_spec.lua
+++ b/spec/unit/sequence_spec.lua
@@ -1,4 +1,5 @@
 require 'spec/custom_asserts'
+local match = require("luassert.match")
 local BehaviourTree = require 'lib/behaviour_tree'
 
 describe('Sequence', function()
@@ -75,12 +76,12 @@ describe('Sequence', function()
     it('should set the current nodes control', function()
       stub(node, 'setControl')
       subject:_run()
-      assert.stub(node.setControl).was.called_with(node, subject)
+      assert.stub(node.setControl).was.called_with(match.is_ref(node), subject)
     end)
     it('should call start on the current node if first run', function()
       stub(node, 'start')
       subject:_run('foo')
-      assert.stub(node.start).was.called_with(node, 'foo')
+      assert.stub(node.start).was.called_with(match.is_ref(node), 'foo')
     end)
     it('should not call start on the current node if running', function()
       subject.node = node
@@ -92,7 +93,7 @@ describe('Sequence', function()
     it('should call run on the current node', function()
       stub(node, 'run')
       subject:_run('foo')
-      assert.stub(node.run).was.called_with(node, 'foo')
+      assert.stub(node.run).was.called_with(match.is_ref(node), 'foo')
     end)
   end)
 


### PR DESCRIPTION
Busted tests 'should call start on the current node on first run'
in branch_node_spec, priority_spec, random_spec, and sequence_spec
were failing because the call:
  assert.stub(node.start).was.called_with(node, 'foo')
would fail due to node being modified between when the stub was
created and the assert. See this issue in luassert:
  https://github.com/Olivine-Labs/luassert/issues/123

The correct course of action was to check that node was a reference
to the same object the stub had been created on, using luassert
match.is_ref(node). I've made this change for all tests where it
seemed to apply.