### PR TITLE
Fix registry instances

### DIFF
--- a/lib/behaviour_tree.lua
+++ b/lib/behaviour_tree.lua
@@ -20,6 +20,13 @@ BehaviourTree.AlwaysSucceedDecorator  = require(_PACKAGE..'/node_types/always_su
 BehaviourTree.register = Registry.register
 BehaviourTree.getNode = Registry.getNode
 
+function BehaviourTree:initialize(config)
+  Node.initialize(self, config)
+  if type(self.tree) == 'string' then
+    self.tree = Registry.getNode(self.tree)
+  end
+end
+
 function BehaviourTree:run(object)
   if self.started then
     Node.running(self) --call running if we have control

--- a/lib/node_types/branch_node.lua
+++ b/lib/node_types/branch_node.lua
@@ -19,7 +19,11 @@ end
 
 function BranchNode:_run(object)
   if not self.nodeRunning then
-    self.node = Registry.getNode(self.nodes[self.actualTask]) 
+    local node = self.nodes[self.actualTask]
+    self.node = Registry.getNode(node)
+    if type(node) == 'string' then
+      self.nodes[self.actualTask] = self.node
+    end
     self.node:start(object)
     self.node:setControl(self)
   end

--- a/lib/registry.lua
+++ b/lib/registry.lua
@@ -2,16 +2,40 @@ local registeredNodes = {}
 
 local Registry = {}
 
-function Registry.register(name, node)
-  registeredNodes[name] = node;
+function Registry.register(nodeTemplates)
+  for name, template in pairs(nodeTemplates) do
+    registeredNodes[name] = template;
+  end
 end
 
-function Registry.getNode(name)
-  if type(name) == 'string' then
-    return registeredNodes[name]
+-- can be name of registered template, node template, or node object
+function Registry.getNode(node)
+  if type(node) == 'string' then
+    local template = registeredNodes[node]
+    return Registry.createNodeFromTemplate(template)
+  elseif node.type then
+    return Registry.createNodeFromTemplate(node)
   else
-    return name
+    return node
   end
+end
+
+function Registry.createNodeFromTemplate(template)
+  if template.nodes then
+    local nodes = {}
+    for i, node in ipairs(template.nodes) do
+      nodes[i] = Registry.getNode(node)
+    end
+    return template.type:new({
+      nodes = nodes
+    })
+  end
+
+  return template.type:new({
+    start = template.start,
+    finish = template.finish,
+    run = template.run,
+  })
 end
 
 return Registry


### PR DESCRIPTION
This is my draft proposal to fix https://github.com/tanema/behaviourtree.lua/issues/8.
What I changed?
- instead of creating a new instance of a node that is then added to the registry and used in multiple trees, the user now creates templates,
- when the user requests a node from the registry, a new instance is created, but with function references from template -> start, finish, run
- if we run the tree again that uses registered nodes, it will use the previously created

Example:
```
local templates = {
  sail_to = {
      type = BehaviourTree.Task,
      run = function(task, ship_id)
         [code]
      end
  },
  sink_ship = {
      type = BehaviourTree.Sequence,
      nodes = {
          'sail_to',
          {
	      type = BehaviourTree.Task,
	      run = function(task, ship_id)
                  [code]
	      end
          },
      },
  },
}
BehaviourTree.register(templates)
```